### PR TITLE
Parâmetro para incluir o linehits no resultado do codecoverage (-xmllines)

### DIFF
--- a/Source/Core/CCE.Core.CodeCoverage.pas
+++ b/Source/Core/CCE.Core.CodeCoverage.pas
@@ -140,7 +140,7 @@ begin
     result := result + '-html ';
 
   if FGenerateXml then
-    result := result + '-xml';
+    result := result + '-xml -xmllines';
 
   result := Format(Result, [FCodeCoverageFileName,
                             GetExeName,


### PR DESCRIPTION
O DelphiCodeCoverage possui o parâmetro -xmllines onde o mesmo cria tags no relatório de cobertura contendo os linehits.
Essa informação é útil quando integramos ao SonarQube, por exemplo.

![image](https://github.com/gabrielbaltazar/code-coverage-experts/assets/41443587/e342dc2f-e31b-476c-afb8-8c2ba8348c90)
